### PR TITLE
GFX dependency removal

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/src/cmake/sdl2-cmake-modules" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/src/include/random" vcs="Git" />
   </component>
 </project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,5 @@ addons:
       - cmake
       - make
       - libsdl2-dev
-      - libsdl2-gfx-dev
 
 script: ./build.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ set(CMAKE_CXX_STANDARD 20)
 
 #set(SDL2_INCLUDE_DIR)
 find_package(SDL2 REQUIRED)
-find_package(SDL2_gfx REQUIRED)
 
 add_subdirectory(src/include/random)
 
@@ -59,5 +58,5 @@ if (WIN64)
 endif(WIN64)
 
 add_executable(Pong src/main.cpp src/Objects/Paddle.cpp src/Objects/Paddle.h src/Utils.cpp src/Utils.h src/Objects/Ball.cpp src/Objects/Ball.h src/PongRPC.cpp src/PongRPC.h src/MP.cpp src/MP.h)
-target_link_libraries(${PROJECT_NAME} SDL2::Main SDL2::GFX effolkronium_random)
+target_link_libraries(${PROJECT_NAME} SDL2::Main effolkronium_random)
 target_link_libraries(${PROJECT_NAME} ${DISCORD_RPC})

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A poorly written port of Pong to SDL2
 ## Building (Linux)
 * 1 . Install the dependencies
 ```bash
-sudo apt install cmake make build-essential gcc libsdl2-dev libsdl2-gfx-dev
+sudo apt install cmake make build-essential gcc libsdl2-dev
 ```
 * 2 . Build
 ```bash

--- a/src/Objects/Ball.cpp
+++ b/src/Objects/Ball.cpp
@@ -5,7 +5,6 @@
 #include <effolkronium/random.hpp>
 #include "Ball.h"
 #include "../Utils.h"
-#include <SDL2/SDL2_gfxPrimitives.h>
 
 using Random = effolkronium::random_static;
 

--- a/src/Objects/Ball.cpp
+++ b/src/Objects/Ball.cpp
@@ -4,6 +4,7 @@
 
 #include <effolkronium/random.hpp>
 #include "Ball.h"
+#include "../Utils.h"
 #include <SDL2/SDL2_gfxPrimitives.h>
 
 using Random = effolkronium::random_static;
@@ -89,7 +90,8 @@ Ball::Ball(int x, int y) {
  * @param pRenderer The target renderer
  */
 void Ball::Render(SDL_Renderer *pRenderer) {
-    filledCircleRGBA(pRenderer, xPos, yPos, radius, colour.r, colour.g, colour.b, colour.a);
+    //filledCircleRGBA(pRenderer, xPos, yPos, radius, colour.r, colour.g, colour.b, colour.a);
+    Utils::DrawFilledCircle(pRenderer, (int)xPos, (int)yPos, radius);
 }
 
 /**

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -32,6 +32,8 @@ void Utils::DrawCircle(SDL_Renderer * renderer, int32_t centreX, int32_t centreY
     int32_t ty = 1;
     int32_t error = (tx - diameter);
 
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+
     while (x >= y) {
         //  Each of the following renders an octant of the circle
         SDL_RenderDrawPoint(renderer, centreX + x, centreY - y);
@@ -54,5 +56,11 @@ void Utils::DrawCircle(SDL_Renderer * renderer, int32_t centreX, int32_t centreY
             tx += 2;
             error += (tx - diameter);
         }
+    }
+}
+
+void Utils::DrawFilledCircle(SDL_Renderer *pRenderer, int centreX, int centreY, int radius) {
+    for (int i = radius; i > 0; i--) {
+        DrawCircle(pRenderer, centreX, centreY, i);
     }
 }

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -13,6 +13,7 @@ class Utils {
 public:
     static int SetDrawColour(SDL_Renderer *renderer, SDL_Color c);
     static void DrawCircle(SDL_Renderer * renderer, int32_t centreX, int32_t centreY, int32_t radius);
+    static void DrawFilledCircle(SDL_Renderer *pRenderer, int centreX, int centreY, int radius);
 };
 
 


### PR DESCRIPTION
Removing the dependency on SDL2_GFX as it seems it can't be compiled very nicely in other OSes, using a more primitive approach by filling a circle with the midpoint algorithm for now, gonna be using something better in the future.